### PR TITLE
Remove non-breaking spaces

### DIFF
--- a/lib/driveshaft/exports/archieml.rb
+++ b/lib/driveshaft/exports/archieml.rb
@@ -19,6 +19,10 @@ module Driveshaft
         match.gsub(/‘|’/, "'")
              .gsub(/“|”/, '"')
       end
+
+      # Remove non-breaking space characters that Google Docs sometimes adds
+      text.gsub!("\u00a0", " ")
+
       data = ::Archieml.load(text)
 
       return {


### PR DESCRIPTION
Google Docs sometimes include these characters, which render as wide spaces.
I can't think of a situation when we'd want them. If we really do want a
non-breaking space, we could use the html entity &nbsp; instead.

Fixes #5 