### PR TITLE
Remove non-breaking spaces

### DIFF
--- a/lib/driveshaft/exports/archieml.rb
+++ b/lib/driveshaft/exports/archieml.rb
@@ -47,7 +47,7 @@ module Driveshaft
             href = parsed_url['q'][0] if parsed_url['q']
           end
 
-          str = "<a href=\"#{href}\">\n"
+          str = "<a href=\"#{href}\">"
           str += convert_node(node)
           str += "</a>"
           return str

--- a/lib/driveshaft/exports/archieml.rb
+++ b/lib/driveshaft/exports/archieml.rb
@@ -19,6 +19,10 @@ module Driveshaft
         match.gsub(/‘|’/, "'")
              .gsub(/“|”/, '"')
       end
+
+      # Remove non-breaking space characters that Google Docs sometimes adds
+      text.gsub!("\u00a0", " ")
+
       data = ::Archieml.load(text)
 
       return {


### PR DESCRIPTION
Google Docs sometimes include these characters, which render as wide spaces.
I can't think of a situation when we'd want them. If we really do want a
non-breaking space, we could use the html entity   instead.

Fixes #5